### PR TITLE
Fix invalid YAML on sql/postgres.yaml

### DIFF
--- a/sql/postgres.yaml
+++ b/sql/postgres.yaml
@@ -92,7 +92,7 @@ queries:
   - collection
   - class
   schema:
-  - property
+  - property:
     description: property name
     type: string
   - n:
@@ -116,7 +116,7 @@ queries:
   - collection
   - class
   schema:
-  - operation
+  - operation:
     description: operation name
     type: string
   - n:
@@ -140,7 +140,7 @@ queries:
   - collection
   - class
   schema:
-  - response
+  - response:
     description: response code or value
     type: string
   - n:
@@ -164,10 +164,10 @@ queries:
   - collection
   - class
   schema:
-  - operation
+  - operation:
     description: operation name
     type: string
-  - response
+  - response:
     description: response code or value
     type: string
   - n:


### PR DESCRIPTION
This PR fixes parts of `sql/postgres.yaml` that were producing errors. It seems that the problem was that some of the keys were being considered "implicit" because of a missing colon character.

I'm not 100% sure if the intent of those keys is the one I understood. That's why I preferred to do this PR instead of pushing what I consider a fix directly to the main branch.